### PR TITLE
Fix supporter URLs

### DIFF
--- a/data/supporters.yml
+++ b/data/supporters.yml
@@ -1,81 +1,81 @@
-- url: https://abgeordnetenwatch.de/"
+- url: https://abgeordnetenwatch.de/
   image: "/partner/aw.png" 
   name: "Abgeordnetenwatch"
-- url: https://wikimedia.de/"
+- url: https://wikimedia.de/
   image: "/partner/wmde-logo.png" 
   name: "Wikimedia"
-- url: https://digitalegesellschaft.de/"
+- url: https://digitalegesellschaft.de/
   image: "/partner/digiges.png" 
   name: "Digitale Gesellschaft"
-- url: https://netzwerkrecherche.org/"
+- url: https://netzwerkrecherche.org/
   image: "/partner/nr.png" 
   name: "Netzwerk Recherche"
-- url: https://ccc.de"
+- url: https://ccc.de
   image: "/partner/CCC.png" 
   name: "CCC"
-- url: https://www.openpetition.de/"
+- url: https://www.openpetition.de/
   image: "/partner/openpetition-logo.png"
-- url: https://www.fiff.de/"
+- url: https://www.fiff.de/
   image: "/partner/fiff.png"
-- url: https://www.reporter-ohne-grenzen.de/"
+- url: https://www.reporter-ohne-grenzen.de/
   image: "/partner/RoG.png"
-- url: https://www.lobbycontrol.de/"
+- url: https://www.lobbycontrol.de/
   image: "/partner/lobbycontrol.png"
-- url: https://changing-cities.org/"
+- url: https://changing-cities.org/
   image: "/partner/changingcities.png"
-- url: http://berlin.humanistische-union.de/"
+- url: http://berlin.humanistische-union.de/
   image: "/partner/humanistischeunion.png"
-- url: https://www.omnibus.org/"
+- url: https://www.omnibus.org/
   image: "/partner/omnibus.png"
-- url: https://www.foodwatch.org/en/homepage/"
+- url: https://www.foodwatch.org/en/homepage/
   image: "/partner/foodwatch.png"
-- url: https://berlin-werbefrei.de/"
+- url: https://berlin-werbefrei.de/
   image: "/partner/werbefrei.png"
-- url: https://ilmr.de/"
+- url: https://ilmr.de/
   image: "/partner/liga_menschenrechte.png"
-- url: https://www.hausderdemokratie.de/"
+- url: https://www.hausderdemokratie.de/
   image: "/partner/haus_menschenrechte.png"
-- url: https://www.dzi.de/"
+- url: https://www.dzi.de/
   image: "/partner/institut_soziale_fragen.png"
-- url: https://berliner-wassertisch.net/"
+- url: https://berliner-wassertisch.net/
   image: "/partner/wassertisch.png"
-- url: https://www.dwenteignen.de/"
+- url: https://www.dwenteignen.de/
   image: "/partner/dw.png"
-- url: https://antikorruptionsvereinberlin.de/"
+- url: https://antikorruptionsvereinberlin.de/
   image: "/partner/antik.png"
-- url: https://www.oedp.de/index.php?id=1678"
+- url: https://www.oedp.de/index.php?id=1678
   image: "/partner/oedp.png"
-- url: https://berlin.piratenpartei.de/"
+- url: https://berlin.piratenpartei.de/
   image: "/partner/piraten.png"
-- url: http://bln-berlin.de/"
+- url: http://bln-berlin.de/
   image: "/partner/lag_naturschutz.png"
-- url: https://bewegung.jetzt/"
+- url: https://bewegung.jetzt/
   image: "/partner/dib.png"
-- url: https://thf100.de/"
+- url: https://thf100.de/
   image: "/partner/logo-thf.png"
-- url: https://www.bund.net/"
+- url: https://www.bund.net/
   image: "/partner/logo-bund.png"
-- url: http://dgif.de/"
+- url: http://dgif.de/
   image: "/partner/logo-dgif.png"
-- url: https://www.grueneliga-berlin.de/"
+- url: https://www.grueneliga-berlin.de/
   image: "/partner/logo-grueneliga.png"
-- url: http://klausenerplatz.de/"
+- url: http://klausenerplatz.de/
   image: "/partner/logo-kiezbuendnis.png"
-- url: https://mafianeindanke.de/"
+- url: https://mafianeindanke.de/
   image: "/partner/logo-mafia.png"
-- url: https://www.whistleblower-net.de/"
+- url: https://www.whistleblower-net.de/
   image: "/partner/logo-wbn.png"
-- url: https://www.naturfreunde-berlin.de/"
+- url: https://www.naturfreunde-berlin.de/
   image: "/partner/logo-nfd.png"
-- url: https://www.volkssolidaritaet.de/berliner-volkssolidaritaet/"
+- url: https://www.volkssolidaritaet.de/berliner-volkssolidaritaet/
   image: "/partner/logo-vs.png"
-- url: https://parentsforfutureberlin.de/"
+- url: https://parentsforfutureberlin.de/
   image: "/partner/parentsforfuture.png"
-- url: https://www.aktion-freiheitstattangst.org/"
+- url: https://www.aktion-freiheitstattangst.org/
   image: "/partner/freiheit-statt-angst.png"
-- url: https://www.gemeingut.org/"
+- url: https://www.gemeingut.org/
   image: "/partner/gemeingut.png"
-- url: https://www.transparency.de/"
+- url: https://www.transparency.de/
   image: "/partner/transparency.png"
-- url: https://oh-yeah.berlin/"
+- url: https://oh-yeah.berlin/
   image: "/partner/ohyeah.png"


### PR DESCRIPTION
The URLs were half-quoted, with double quotes at the end but not at the beginning, which the YAML parser interpreted as literal double quotes at the end of the URL, leading to links like this:

```html
<a href="https://abgeordnetenwatch.de/%22">
    <img class="img-fluid" src="/partner/aw.png" alt="Abgeordnetenwatch">
</a>
```

Fixed by removing the trailing double quotes with the following command:

```sh
sed -i '/^- url: [^"]/ s/"$//' data/supporters.yml
```

Of course, an alternative fix would be to fully quote the URLs by adding double quotes at the beginning as well.